### PR TITLE
"Developing in the monorepo" instructions incomplete

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,10 @@ If you want to make a pull request, please adhere to the following:
 To develop a module first clone the repo (it‘s recommended you rename the folder from `node_modules`). Next switch into the directory of the module you want to work on. Finally (and this is really important) call `source .env`. What this does is it takes all of the scripts and makes them available to you as you develop.
 
 ```bash
-$ git clone https://github.com/calebmer/node_modules.git node-modules
-$ cd node_modules/{module-i-want-to-work-on}
+$ git clone https://github.com/calebmer/node_modules.git calebmer_monorepo
+$ cd calebmer_monorepo
+$ npm install
+$ cd {module-i-want-to-work-on}
 $ source .env
 ```
 


### PR DESCRIPTION
I ran into a problem with the previous startup instructions.

`_scripts/build.sh` and friends assume tools in `../node_modules/.bin` relative to `_scripts`.

https://github.com/calebmer/node_modules/blob/770648585a7f96aa75604578146a08a8aec8bbf6/_scripts/build.sh#L7-L9

Normally `npm install` in a directory that contains a `package.json` will create a `node_modules` subdirectory, but not when the current directory is named `node_modules`.

Renaming the `node_modules` directory to something else, running `npm install`, and then changing the directory back does not work because `require(...)` will not look for a `node_modules` subdirectory inside a `node_modules` directory.

This happens because of how [`require(...)` searches](https://nodejs.org/api/modules.html#modules_all_together) ancestor-ward:

> NODE_MODULES_PATHS(START)
> 1. let PARTS = path split(START)
> 2. let I = count of PARTS - 1
> 3. let DIRS = [GLOBAL_FOLDERS]
> 4. while I >= 0,
>    a. **if PARTS[I] = "node_modules" CONTINUE**

The changed setup instructions address the problem by cloning into a different directory name so that there is no `node_modules` path element on "$PWD".