### PR TITLE
JSX transform should work with valueless attributes

### DIFF
--- a/babel-plugin-transform-jsx/src/index.js
+++ b/babel-plugin-transform-jsx/src/index.js
@@ -135,7 +135,9 @@ export default function ({ types: t }) {
             const attributeName = JSXAttributeName(node.name)
             const objectKey = esutils.keyword.isIdentifierNameES6(attributeName.value) ? t.identifier(attributeName.value) : attributeName
 
-            object.push(t.objectProperty(objectKey, JSXAttributeValue(node.value)))
+            const value = node.value !== null ? node.value : attributeName
+
+            object.push(t.objectProperty(objectKey, JSXAttributeValue(value)))
             break
           }
           case 'JSXSpreadAttribute': {

--- a/babel-plugin-transform-jsx/test/fixtures/should-work-with-valueless-attributes/actual.js
+++ b/babel-plugin-transform-jsx/test/fixtures/should-work-with-valueless-attributes/actual.js
@@ -1,0 +1,1 @@
+export default <input checked />;

--- a/babel-plugin-transform-jsx/test/fixtures/should-work-with-valueless-attributes/expected.js
+++ b/babel-plugin-transform-jsx/test/fixtures/should-work-with-valueless-attributes/expected.js
@@ -1,0 +1,7 @@
+export default {
+  elementName: "input",
+  attributes: {
+    checked: "checked"
+  },
+  children: null
+};


### PR DESCRIPTION
Prior to this change, rewriting the below failed with an Error.

```jsx
    <input checked />
```

https://github.com/facebook/jsx says

> ```bnf
> JSXAttribute : 
>     JSXAttributeName JSXAttributeInitializeropt
> ```

The JSXAttributeInitializer is optional.

Normal HTML parsing rules say that a valueless attribute specifies an
attribute whose value is the same as its name.

Unresolved: Should we case-adjust the implied value per HTML rules.

I have not surveyed other plugins to see what they do.