### PR TITLE
Distinguished literals

### DIFF
--- a/babel-plugin-transform-jsx/src/index.js
+++ b/babel-plugin-transform-jsx/src/index.js
@@ -135,7 +135,9 @@ export default function ({ types: t }) {
             const attributeName = JSXAttributeName(node.name)
             const objectKey = esutils.keyword.isIdentifierNameES6(attributeName.value) ? t.identifier(attributeName.value) : attributeName
 
-            object.push(t.objectProperty(objectKey, JSXAttributeValue(node.value)))
+            const value = node.value !== null ? node.value : attributeName
+
+            object.push(t.objectProperty(objectKey, JSXAttributeValue(value)))
             break
           }
           case 'JSXSpreadAttribute': {

--- a/babel-plugin-transform-jsx/test/fixtures/should-distinguish-literals-with-option/actual.js
+++ b/babel-plugin-transform-jsx/test/fixtures/should-distinguish-literals-with-option/actual.js
@@ -1,0 +1,8 @@
+export default function (str) {
+  return [
+      <a href="javascript:go()" valueless>Text</a>,
+      <a href={"javascript:go()"}>{"Text"}</a>,
+      <a href={str} {...({ spreaded: "" })}>{str}</a>,
+      <a href={`${str}`}>Back ticks with an interpolation</a>
+  ];
+}

--- a/babel-plugin-transform-jsx/test/fixtures/should-distinguish-literals-with-option/expected.js
+++ b/babel-plugin-transform-jsx/test/fixtures/should-distinguish-literals-with-option/expected.js
@@ -1,0 +1,28 @@
+export default function (str) {
+    return [{
+        elementName: "a",
+        attributes: {
+            href: new LiteralNode("javascript:go()", "a href"),
+            valueless: new LiteralNode("valueless", "a valueless")
+        },
+        children: [new LiteralNode("Text", "#text")]
+    }, {
+        elementName: "a",
+        attributes: {
+            href: "javascript:go()"
+        },
+        children: [new LiteralNode("Text", "#text")]
+    }, {
+        elementName: "a",
+        attributes: babelHelpers.extends({
+            href: str
+        }, { spreaded: "" }),
+        children: [str]
+    }, {
+        elementName: "a",
+        attributes: {
+            href: `${str}`
+        },
+        children: [new LiteralNode("Back ticks with an interpolation", "#text")]
+    }];
+}

--- a/babel-plugin-transform-jsx/test/fixtures/should-distinguish-literals-with-option/options.json
+++ b/babel-plugin-transform-jsx/test/fixtures/should-distinguish-literals-with-option/options.json
@@ -1,0 +1,4 @@
+{
+  "useNew": true,
+  "literals": "LiteralNode"
+}

--- a/babel-plugin-transform-jsx/test/fixtures/should-work-with-valueless-attributes/actual.js
+++ b/babel-plugin-transform-jsx/test/fixtures/should-work-with-valueless-attributes/actual.js
@@ -1,0 +1,1 @@
+export default <input checked />;

--- a/babel-plugin-transform-jsx/test/fixtures/should-work-with-valueless-attributes/expected.js
+++ b/babel-plugin-transform-jsx/test/fixtures/should-work-with-valueless-attributes/expected.js
@@ -1,0 +1,7 @@
+export default {
+  elementName: "input",
+  attributes: {
+    checked: "checked"
+  },
+  children: null
+};


### PR DESCRIPTION
Option to distinguish literal attributes and text nodes.

An option `{ literals: "functionName" }` now wraps literal attribute
and text node values in a call to `functionName("text", "context hint")`.

For background, ["Options for Hardening React &| JSX"](https://gist.github.com/mikesamuel/094d3fe4b1b2f702f543fa0c263ca8ff) discusses ways to address XSS and crafted intents in JSX Frameworks like React and React native.

> Desugar string literals in JSXAttributeValue and JSXText nodes so
> that they are clearly marked as specified by a trusted developer.

This should allow `ReactDOM` to prevent `javascript:` URLs that reach

```jsx
(<a href={url}>Link</a>)
```

without preventing developers from doing something like

```jsx
(<a href="javascript:doSomethingAwesome()">Link</a>)
```

This is meant to eventually interoperate with the [trusted-types](https://github.com/WICG/trusted-types) polyfill.
